### PR TITLE
update fields in the example custom config file

### DIFF
--- a/aas_cfg.c
+++ b/aas_cfg.c
@@ -83,6 +83,7 @@ fielddef_t cfg_fields[] =
 	{"rs_startelevator", CFG_OFS(rs_startelevator), FT_FLOAT},
 	{"rs_falldamage5", CFG_OFS(rs_falldamage5), FT_FLOAT},
 	{"rs_falldamage10", CFG_OFS(rs_falldamage10), FT_FLOAT},
+	{"rs_maxfallheight", CFG_OFS(rs_maxfallheight), FT_FLOAT},
 	{"rs_maxjumpfallheight", CFG_OFS(rs_maxjumpfallheight), FT_FLOAT},
 	{NULL, 0, 0, 0}
 };

--- a/aas_cfg.h
+++ b/aas_cfg.h
@@ -64,6 +64,7 @@ typedef struct cfg_s
 	float rs_startelevator;
 	float rs_falldamage5;
 	float rs_falldamage10;
+	float rs_maxfallheight;
 	float rs_maxjumpfallheight;
 } cfg_t;
 

--- a/cfgq3.c
+++ b/cfgq3.c
@@ -56,11 +56,12 @@ settings
 	phys_maxwalkvelocity		320
 	phys_maxcrouchvelocity		100
 	phys_maxswimvelocity		150
-	phys_maxacceleration		2200
-	phys_airaccelerate			0
-	phys_maxstep				18
+	phys_walkaccelerate		10
+	phys_airaccelerate			1
+	phys_swimaccelerate			4
+	phys_maxstep				19
 	phys_maxsteepness			0.7
-	phys_maxwaterjump			19
+	phys_maxwaterjump			18
 	phys_maxbarrier				33
 	phys_jumpvel				270
 	phys_falldelta5				40
@@ -80,5 +81,6 @@ settings
 	rs_startelevator			50
 	rs_falldamage5				300
 	rs_falldamage10				500
+	rs_maxfallheight		0
 	rs_maxjumpfallheight		450
 } //end settings


### PR DESCRIPTION
The settings in cfgq3.c had diverged from the actual fields and defaults in
these ways:
- extra field phys_maxacceleration
- missing fields phys_walkaccelerate, phys_swimaccelerate, rs_maxfallheight
- different defaults for phys_airaccelerate, phys_maxstep, phys_maxwaterjump

Also the code in aas_cfg.[ch] for reading the settings was missing
rs_maxfallheight.

It's brittle to require multiple different files to agree on these fields, but
rather than fix that issue this is just a band-aid to bring things back into
alignment so that custom configs based on the example file can be used again.

Testing: just generating aas for jlctf3 with and without custom configs, seeing
changes in the reported stats, and checking that they were playable.
