### PR TITLE
fix checksum calculation on non-Windows platforms

### DIFF
--- a/deps/qcommon/md4.c
+++ b/deps/qcommon/md4.c
@@ -12,7 +12,7 @@ typedef unsigned char *POINTER;
 typedef unsigned short int UINT2;
 
 /* UINT4 defines a four byte word */
-typedef unsigned long int UINT4;
+typedef unsigned int UINT4;
 
   
 /* MD4.H - header file for MD4C.C */


### PR DESCRIPTION
With bspc built on OS X or Centos, a generated aas file for a given bsp
is exactly the same as when generated on Windows, except for the
checksum.

The reason is that on those platforms, the UINT4 data type defined in
md4.c is 8 bytes in size rather than 4 bytes.

Changing that type definition from "unsigned long int" to "unsigned int"
makes the data type 4 bytes in size on all three platforms, resulting in
correct & identical aas files for all three.

It's not a bulletproof way of specifying a 4-byte int, but as far as I
know it should be 4 bytes on any current platform that could build & run
bspc.
