### PR TITLE
Add FBSP support to bspc and squash a few bugs along the way

### DIFF
--- a/brushbsp.c
+++ b/brushbsp.c
@@ -425,7 +425,7 @@ bspbrush_t *AllocBrush (int numsides)
 	bspbrush_t	*bb;
 	size_t		c;
 
-	c = offsetof(bspbrush_t, sides[numsides]);
+	c = sizeof(*bb) + (numsides > 6 ? sizeof(side_t)*(numsides-6) : 0);
 	bb = GetMemory(c);
 	memset (bb, 0, c);
 	if (numthreads == 1)
@@ -488,7 +488,7 @@ bspbrush_t *CopyBrush (bspbrush_t *brush)
 	size_t		size;
 	int			i;
 	
-	size = offsetof(bspbrush_t, sides[brush->numsides]);
+	size = sizeof(*newbrush) + (brush->numsides > 6 ? sizeof(side_t)*(brush->numsides-6) : 0);
 
 	newbrush = AllocBrush (brush->numsides);
 	memcpy (newbrush, brush, size);

--- a/brushbsp.c
+++ b/brushbsp.c
@@ -1016,10 +1016,10 @@ side_t *SelectSplitSide (bspbrush_t *brushes, node_t *node)
 				pnum = side->planenum;
 				pnum &= ~1;	// allways use positive facing plane
 
-				CheckPlaneAgainstParents (pnum, node);
-
 				if (!CheckPlaneAgainstVolume (pnum, node))
 					continue;	// would produce a tiny volume
+
+				CheckPlaneAgainstParents (pnum, node);
 
 				front = 0;
 				back = 0;

--- a/deps/botlib/be_aas_move.c
+++ b/deps/botlib/be_aas_move.c
@@ -168,7 +168,7 @@ int AAS_AgainstLadder(vec3_t origin)
 		//get the plane the face is in
 		plane = &aasworld.planes[face->planenum ^ side];
 		//if the origin is pretty close to the plane
-		if (abs(DotProduct(plane->normal, origin) - plane->dist) < 3)
+		if (fabs(DotProduct(plane->normal, origin) - plane->dist) < 3.0f)
 		{
 			if (AAS_PointInsideFace(abs(facenum), origin, 0.1f)) return qtrue;
 		} //end if

--- a/deps/botlib/be_aas_reach.c
+++ b/deps/botlib/be_aas_reach.c
@@ -2472,16 +2472,16 @@ int AAS_Reachability_Ladder(int area1num, int area2num)
 		VectorMA(area1point, -32, dir, area1point);
 		VectorMA(area2point, 32, dir, area2point);
 		//
-		ladderface1vertical = abs(DotProduct(plane1->normal, up)) < 0.1;
-		ladderface2vertical = abs(DotProduct(plane2->normal, up)) < 0.1;
+		ladderface1vertical = fabs(DotProduct(plane1->normal, up)) < 0.1f;
+		ladderface2vertical = fabs(DotProduct(plane2->normal, up)) < 0.1f;
 		//there's only reachability between vertical ladder faces
 		if (!ladderface1vertical && !ladderface2vertical) return qfalse;
 		//if both vertical ladder faces
 		if (ladderface1vertical && ladderface2vertical
 					//and the ladder faces do not make a sharp corner
-					&& DotProduct(plane1->normal, plane2->normal) > 0.7
+					&& DotProduct(plane1->normal, plane2->normal) > 0.7f
 					//and the shared edge is not too vertical
-					&& abs(DotProduct(sharededgevec, up)) < 0.7)
+					&& fabs(DotProduct(sharededgevec, up)) < 0.7f)
 		{
 			//create a new reachability link
 			lreach = AAS_AllocReachability();
@@ -2606,7 +2606,7 @@ int AAS_Reachability_Ladder(int area1num, int area2num)
 				if (face2->faceflags & FACE_LADDER)
 				{
 					plane2 = &aasworld.planes[face2->planenum];
-					if (abs(DotProduct(plane2->normal, up)) < 0.1) break;
+					if (fabs(DotProduct(plane2->normal, up)) < 0.1f) break;
 				} //end if
 			} //end for
 			//if from another area without vertical ladder faces

--- a/deps/qcommon/qfiles.h
+++ b/deps/qcommon/qfiles.h
@@ -402,9 +402,12 @@ typedef struct {
 
 #define BSP_IDENT	(('P'<<24)+('S'<<16)+('B'<<8)+'I')
 		// little-endian "IBSP"
+#define BSP_IDENT_QF	(('P'<<24)+('S'<<16)+('B'<<8)+'F')
+		// little-endian "IBSP"
 
 #define BSP_VERSION			46
 #define BSP_VERSION_QL			47 // quakelive :sss
+#define BSP_VERSION_QF			1 // qfusion
 
 // there shouldn't be any problem with increasing these values at the
 // expense of more memory allocation in the utilities
@@ -442,6 +445,8 @@ typedef struct {
 
 #define	LIGHTMAP_WIDTH		128
 #define	LIGHTMAP_HEIGHT		128
+
+#define MAX_LIGHTMAPS       4
 
 #define MAX_WORLD_COORD		( 128*1024 )
 #define MIN_WORLD_COORD		( -128*1024 )
@@ -526,6 +531,12 @@ typedef struct {
 } dbrushside_t;
 
 typedef struct {
+	int			planeNum;			// positive plane side faces out of the leaf
+	int			shaderNum;
+    int         surfaceNum;
+} drbrushside_t;
+
+typedef struct {
 	int			firstSide;
 	int			numSides;
 	int			shaderNum;		// the shader that determines the contents flags
@@ -544,6 +555,14 @@ typedef struct {
 	vec3_t		normal;
 	byte		color[4];
 } drawVert_t;
+
+typedef struct {
+	vec3_t		xyz;
+	float		st[2];
+	float		lightmap[MAX_LIGHTMAPS][2];
+	vec3_t		normal;
+	byte		color[MAX_LIGHTMAPS][4];
+} rdrawVert_t;
 
 #define drawVert_t_cleared(x) drawVert_t (x) = {{0, 0, 0}, {0, 0}, {0, 0}, {0, 0, 0}, {0, 0, 0, 0}}
 
@@ -577,5 +596,29 @@ typedef struct {
 	int			patchHeight;
 } dsurface_t;
 
+typedef struct {
+	int			shaderNum;
+	int			fogNum;
+	int			surfaceType;
+
+	int			firstVert;
+	int			numVerts;
+
+	int			firstIndex;
+	int			numIndexes;
+
+    unsigned char lightmapStyles[MAX_LIGHTMAPS];
+    unsigned char vertexStyles[MAX_LIGHTMAPS];
+
+	int			lightmapNum[MAX_LIGHTMAPS];
+	int			lightmapXY[MAX_LIGHTMAPS][2];
+	int			lightmapWidth, lightmapHeight;
+
+	vec3_t		lightmapOrigin;
+	vec3_t		lightmapVecs[3];	// for patches, [0] and [1] are lodbounds
+
+	int			patchWidth;
+	int			patchHeight;
+} drsurface_t;
 
 #endif

--- a/l_poly.c
+++ b/l_poly.c
@@ -71,7 +71,7 @@ winding_t *AllocWinding (int points)
 	winding_t	*w;
 	int			s;
 
-	s = sizeof(vec_t)*3*points + sizeof(int);
+	s = sizeof(*w) + (points > 4 ? sizeof(vec3_t)*(points-4) : 0);
 	w = GetMemory(s);
 	memset(w, 0, s);
 

--- a/map.c
+++ b/map.c
@@ -1219,6 +1219,13 @@ int LoadMapFromBSP(struct quakefile_s *qf)
 		Q3_LoadMapFromBSP(qf);
 		Q3_FreeMaxBSP();
 	} //end if
+	//Qfusion BSP file
+	else if (idheader.ident == QF_BSP_IDENT && idheader.version == QF_BSP_VERSION)
+	{
+		ResetMapLoading();
+		Q3_LoadMapFromBSP(qf);
+		Q3_FreeMaxBSP();
+	} //end if
 	//Quake3 BSP file
 	else if (idheader.ident == Q3_BSP_IDENT && idheader.version == Q3_BSP_VERSION)
 	{

--- a/q3files.h
+++ b/q3files.h
@@ -210,6 +210,12 @@ typedef struct {
 		// little-endian "IBSP"
 
 #define QL_BSP_VERSION			47
+
+#define QF_BSP_IDENT	(('P'<<24)+('S'<<16)+('B'<<8)+'F')
+		// little-endian "IBSP"
+
+#define QF_BSP_VERSION			1
+
 // ***********************************************************
 
 // there shouldn't be any problem with increasing these values at the
@@ -249,6 +255,7 @@ typedef struct {
 #define	LIGHTMAP_WIDTH		128
 #define	LIGHTMAP_HEIGHT		128
 
+#define MAX_LIGHTMAPS       4
 
 //=============================================================================
 
@@ -329,6 +336,12 @@ typedef struct {
 } q3_dbrushside_t;
 
 typedef struct {
+	int			planeNum;			// positive plane side faces out of the leaf
+	int			shaderNum;
+	int			surfaceNum;
+} q3r_dbrushside_t;
+
+typedef struct {
 	int			firstSide;
 	int			numSides;
 	int			shaderNum;		// the shader that determines the contents flags
@@ -347,6 +360,14 @@ typedef struct {
 	vec3_t		normal;
 	byte		color[4];
 } q3_drawVert_t;
+
+typedef struct {
+	vec3_t		xyz;
+	float		st[2];
+	float		lightmap[MAX_LIGHTMAPS][2];
+	vec3_t		normal;
+	byte		color[MAX_LIGHTMAPS][4];
+} q3r_drawVert_t;
 
 typedef enum {
 	MST_BAD,
@@ -378,5 +399,29 @@ typedef struct {
 	int			patchHeight;
 } q3_dsurface_t;
 
+typedef struct {
+	int			shaderNum;
+	int			fogNum;
+	int			surfaceType;
+
+	int			firstVert;
+	int			numVerts;
+
+	int			firstIndex;
+	int			numIndexes;
+
+	unsigned char lightmapStyles[MAX_LIGHTMAPS];
+	unsigned char vertexStyles[MAX_LIGHTMAPS];
+
+	int			lightmapNum[MAX_LIGHTMAPS];
+	int			lightmapXY[MAX_LIGHTMAPS][2];
+	int			lightmapWidth, lightmapHeight;
+
+	vec3_t		lightmapOrigin;
+	vec3_t		lightmapVecs[3];	// for patches, [0] and [1] are lodbounds
+
+	int			patchWidth;
+	int			patchHeight;
+} q3r_dsurface_t;
 
 #endif

--- a/qbsp.h
+++ b/qbsp.h
@@ -85,7 +85,7 @@ typedef struct side_s
 	int				texinfo;		// texture reference
 	winding_t		*winding;	// winding of this side
 	struct side_s	*original;	// bspbrush_t sides will reference the mapbrush_t sides
-   int				lightinfo;	// for SIN only
+	int				lightinfo;	// for SIN only
 	int				contents;	// from miptex
 	int				surf;			// from miptex
 	unsigned short flags;		// side flags


### PR DESCRIPTION
FBSP is a flavor of Raven's IBSP, which is used by the Qfusion engine. With FBSP supported, adding RBSP support should be trivial now.

The changeset also includes among other things, fixes for compilation warnings and the notorious 'Tried parent' error.
