### PR TITLE
[l_bsp_{hl,q1}.c] Fix erroneous use of comma operator

### DIFF
--- a/l_bsp_hl.c
+++ b/l_bsp_hl.c
@@ -151,7 +151,7 @@ void HL_AllocMaxBSP(void)
 	//edges
 	hl_numedges = 0;
 	hl_dedges = (hl_dedge_t *) GetMemory(HL_MAX_MAP_EDGES * sizeof(hl_dedge_t));
-	hl_allocatedbspmem += HL_MAX_MAP_EDGES, sizeof(hl_dedge_t);
+	hl_allocatedbspmem += HL_MAX_MAP_EDGES * sizeof(hl_dedge_t);
 	//mark surfaces
 	hl_nummarksurfaces = 0;
 	hl_dmarksurfaces = (unsigned short *) GetMemory(HL_MAX_MAP_MARKSURFACES * sizeof(unsigned short));

--- a/l_bsp_q1.c
+++ b/l_bsp_q1.c
@@ -133,7 +133,7 @@ void Q1_AllocMaxBSP(void)
 	//edges
 	q1_numedges = 0;
 	q1_dedges = (q1_dedge_t *) GetMemory(Q1_MAX_MAP_EDGES * sizeof(q1_dedge_t));
-	q1_allocatedbspmem += Q1_MAX_MAP_EDGES, sizeof(q1_dedge_t);
+	q1_allocatedbspmem += Q1_MAX_MAP_EDGES * sizeof(q1_dedge_t);
 	//mark surfaces
 	q1_nummarksurfaces = 0;
 	q1_dmarksurfaces = (unsigned short *) GetMemory(Q1_MAX_MAP_MARKSURFACES * sizeof(unsigned short));


### PR DESCRIPTION
Please let me know if you think that this is a genuine bug. The code has been like that since the original source dump.
