### PR TITLE
[bspc.c] Change directory variables to have static storage

### DIFF
--- a/bspc.c
+++ b/bspc.c
@@ -271,8 +271,8 @@ quakefile_t *GetArgumentFiles(int argc, char *argv[], int *i, char *ext)
 int main (int argc, char **argv)
 {
 	int i, comp = 0;
-	char outputpath[MAX_PATH] = "";
-	char filename[MAX_PATH] = "unknown";
+	static char outputpath[MAX_PATH] = "";
+	static char filename[MAX_PATH] = "unknown";
 	quakefile_t *qfiles, *qf;
 	double start_time;
 


### PR DESCRIPTION
@TTimo: Hi - I'm sending you a bunch of PRs, mostly fixes of bugs reported by compiler warnings. This PR is a bit different; it increases the limit on path lengths. If you don't care for this, just close the PR.
