### PR TITLE
Use flexible array members

### DIFF
--- a/brushbsp.c
+++ b/brushbsp.c
@@ -425,7 +425,7 @@ bspbrush_t *AllocBrush (int numsides)
 	bspbrush_t	*bb;
 	size_t		c;
 
-	c = sizeof(*bb) + (numsides > 6 ? sizeof(side_t)*(numsides-6) : 0);
+	c = sizeof(*bb) + sizeof(*bb->sides) * numsides;
 	bb = GetMemory(c);
 	memset (bb, 0, c);
 	if (numthreads == 1)
@@ -487,8 +487,8 @@ bspbrush_t *CopyBrush (bspbrush_t *brush)
 	bspbrush_t *newbrush;
 	size_t		size;
 	int			i;
-	
-	size = sizeof(*newbrush) + (brush->numsides > 6 ? sizeof(side_t)*(brush->numsides-6) : 0);
+
+	size = sizeof(*newbrush) + sizeof(*brush->sides) * brush->numsides;
 
 	newbrush = AllocBrush (brush->numsides);
 	memcpy (newbrush, brush, size);

--- a/l_poly.c
+++ b/l_poly.c
@@ -71,7 +71,7 @@ winding_t *AllocWinding (int points)
 	winding_t	*w;
 	int			s;
 
-	s = sizeof(*w) + (points > 4 ? sizeof(vec3_t)*(points-4) : 0);
+	s = sizeof(*w) + sizeof(*w->p) * points;
 	w = GetMemory(s);
 	memset(w, 0, s);
 
@@ -157,7 +157,7 @@ void RemoveColinearPoints (winding_t *w)
 	if (numthreads == 1)
 		c_removed += w->numpoints - nump;
 	w->numpoints = nump;
-	memcpy (w->p, p, nump*sizeof(p[0]));
+	memcpy (w->p, p, nump * sizeof(*w->p));
 }
 
 /*
@@ -325,7 +325,7 @@ winding_t *CopyWinding (winding_t *w)
 	winding_t	*c;
 
 	c = AllocWinding (w->numpoints);
-	size = sizeof(*w) + (w->numpoints > 4 ? sizeof(vec3_t)*(w->numpoints-4) : 0);
+	size = sizeof(*w) + sizeof(*w->p) * w->numpoints;
 	memcpy (c, w, size);
 	return c;
 }

--- a/l_poly.h
+++ b/l_poly.h
@@ -24,7 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 typedef struct
 {
 	int		numpoints;
-	vec3_t	p[4];			//variable sized
+	vec3_t	p[];
 } winding_t;
 
 #define	MAX_POINTS_ON_WINDING	96

--- a/qbsp.h
+++ b/qbsp.h
@@ -140,7 +140,7 @@ typedef struct bspbrush_s
 	int			side, testside;		// side of node during construction
 	mapbrush_t	*original;
 	int			numsides;
-	side_t		sides[6];			// variably sized
+	side_t		sides[];
 } bspbrush_t;	//sizeof(bspbrush_t) = 44 + numsides * sizeof(side_t)
 //bsp node
 typedef struct node_s


### PR DESCRIPTION
Change winding_t and bspbrush_t to use flexible array members rather than size-1 arrays.

The arrays were always meant to be variably sized, and objects are only ever allocated dynamically. Object size computations are simplified with this change.

Flexible arrays were introduced in C99, so this change means that we will require a C99-conforming compiler henceforth.

I leave it up to you to decide whether that's acceptable, and whether the build system needs changing. I think GCC changed its defaults to C11 and C++14 in version 6, but for other compilers we should probably add an explicit `-std=c99` flag.